### PR TITLE
Fix: monograph object parts not handled properly

### DIFF
--- a/edoweb-sync/src/main/java/de/nrw/hbz/regal/sync/ingest/EdowebIngester.java
+++ b/edoweb-sync/src/main/java/de/nrw/hbz/regal/sync/ingest/EdowebIngester.java
@@ -362,12 +362,7 @@ public class EdowebIngester implements IngestInterface {
 	webclient.autoGenerateMetdata(dtlBean);
 	webclient.addUrn(dtlBean.getPid(), namespace, "hbz:929:02");
 	webclient.makeOaiSet(dtlBean);
-	if (dtlBean.getStream(StreamType.DATA).getMimeType()
-		.compareTo("application/pdf") == 0) {
-	    dtlBean.setParentPid(dtlBean.getPid());
-	    dtlBean.setPid(dtlBean.getPid() + "-1");
-	    updateFile(dtlBean);
-	}
+	includeDataStreamIfAvailable(dtlBean);
 	List<DigitalEntity> list = getParts(dtlBean);
 	int num = list.size();
 	int count = 1;
@@ -377,6 +372,20 @@ public class EdowebIngester implements IngestInterface {
 	    updatePart(b);
 	}
 	logger.info(pid + " " + "updated.\n");
+    }
+
+    private void includeDataStreamIfAvailable(DigitalEntity dtlBean) {
+	try {
+	    if (dtlBean.getStream(StreamType.DATA).getMimeType()
+		    .compareTo("application/pdf") == 0) {
+		dtlBean.setParentPid(dtlBean.getPid());
+		dtlBean.setPid(dtlBean.getPid() + "-1");
+		updateFile(dtlBean);
+		logger.debug("Found direct data stream for " + dtlBean.getPid());
+	    }
+	} catch (Exception e) {
+	    logger.debug("No data stream found for " + dtlBean.getPid());
+	}
     }
 
     private void updateJournal(DigitalEntity dtlBean) {


### PR DESCRIPTION
- the bug was introduced by 035ece. The commit removes
catch clauses to make the creation of resources more accurate.
By this the creation of a data stream has been wrongly introduced
as mandatory.